### PR TITLE
Remove debug logging from reproducible build test

### DIFF
--- a/integration/reproducible_layer_rebuild_test.go
+++ b/integration/reproducible_layer_rebuild_test.go
@@ -72,7 +72,6 @@ func testReproducibleLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 					procfileBuildpack,
 				).
 				WithEnv(map[string]string{
-					"BP_LOG_LEVEL":  "DEBUG",
 					"BP_PHP_SERVER": "httpd",
 				})
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Nitpick fix to https://github.com/paketo-buildpacks/php-httpd/pull/12 but I merged it in and noticed we should remove the debug logging from the test for clarity's sake.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
