### PR TITLE
Allows UID to differ between build and run

### DIFF
--- a/assets/default.conf
+++ b/assets/default.conf
@@ -3,6 +3,7 @@ Listen ${PORT}
 ServerAdmin "{{.ServerAdmin}}"
 ServerName "0.0.0.0"
 DocumentRoot "{{.AppRoot}}/{{.WebDirectory}}"
+PidFile /tmp/httpd.pid
 
 # Load only modules required for PHP
 LoadModule authz_core_module modules/mod_authz_core.so

--- a/build.go
+++ b/build.go
@@ -11,7 +11,7 @@ import (
 // ConfigWriter sets up the HTTPD configuration file with defaults, and adds in
 // user-set environment variables.
 type ConfigWriter interface {
-	Write(layerPath, workingDir, cnbPath string) (string, error)
+	Write(layerPath, workingDir string) (string, error)
 }
 
 // Build will return a packit.BuildFunc that will be invoked during the build
@@ -39,7 +39,7 @@ func Build(config ConfigWriter, logger scribe.Emitter) packit.BuildFunc {
 		}
 
 		logger.Process("Setting up the HTTPD configuration file")
-		httpdConfigPath, err := config.Write(phpHttpdLayer.Path, context.WorkingDir, context.CNBPath)
+		httpdConfigPath, err := config.Write(phpHttpdLayer.Path, context.WorkingDir)
 		if err != nil {
 			return packit.BuildResult{}, err
 		}

--- a/build_test.go
+++ b/build_test.go
@@ -97,7 +97,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(config.WriteCall.Receives.LayerPath).To(Equal(filepath.Join(layerDir, "php-httpd-config")))
 		Expect(config.WriteCall.Receives.WorkingDir).To(Equal(workingDir))
-		Expect(config.WriteCall.Receives.CnbPath).To(Equal(cnbDir))
 
 		Expect(result.Layers).To(HaveLen(1))
 		Expect(result.Layers[0]).To(Equal(expectedPhpLayer))

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -12,7 +12,7 @@ api = "0.7"
     uri = "https://github.com/paketo-buildpacks/php-httpd/blob/main/LICENSE"
 
 [metadata]
-  include-files = ["bin/build", "bin/detect", "bin/run", "buildpack.toml", "config/httpd.conf"]
+  include-files = ["bin/build", "bin/detect", "bin/run", "buildpack.toml"]
   pre-package = "./scripts/build.sh"
 
 [[stacks]]

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package phphttpd
 
 import (
 	"bytes"
+	_ "embed"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +13,9 @@ import (
 
 	"github.com/paketo-buildpacks/packit/v2/scribe"
 )
+
+//go:embed assets/default.conf
+var DefaultHTTPDConfTemplate string
 
 type HttpdConfig struct {
 	ServerAdmin          string
@@ -32,8 +36,8 @@ func NewConfig(logger scribe.Emitter) Config {
 	}
 }
 
-func (c Config) Write(layerPath, workingDir, cnbPath string) (string, error) {
-	tmpl, err := template.New("httpd.conf").ParseFiles(filepath.Join(cnbPath, "config", "httpd.conf"))
+func (c Config) Write(layerPath, workingDir string) (string, error) {
+	tmpl, err := template.New("httpd.conf").Parse(DefaultHTTPDConfTemplate)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse HTTPD config template: %w", err)
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -20,7 +20,6 @@ func testConfig(t *testing.T, context spec.G, it spec.S) {
 
 		layerDir   string
 		workingDir string
-		cnbDir     string
 		config     phphttpd.Config
 	)
 
@@ -33,32 +32,17 @@ func testConfig(t *testing.T, context spec.G, it spec.S) {
 		workingDir, err = os.MkdirTemp("", "workingDir")
 		Expect(err).NotTo(HaveOccurred())
 
-		cnbDir, err = os.MkdirTemp("", "cnb")
-		Expect(err).NotTo(HaveOccurred())
-
-		Expect(os.MkdirAll(filepath.Join(cnbDir, "config"), os.ModePerm)).To(Succeed())
-		Expect(os.WriteFile(filepath.Join(cnbDir, "config", "httpd.conf"), []byte(`
-ServerAdmin {{.ServerAdmin}}
-DocumentRoot {{.AppRoot}}/{{.WebDirectory}}
-FPMSocket {{.FpmSocket}}
-DisableHTTPSRedirect {{.DisableHTTPSRedirect }}
-{{ if ne .UserInclude "" }}
-IncludeOptional {{ .UserInclude }}
-{{- end}}
-`), os.ModePerm)).To(Succeed())
-
 		logEmitter := scribe.NewEmitter(bytes.NewBuffer(nil))
 		config = phphttpd.NewConfig(logEmitter)
 	})
 
 	it.After(func() {
 		Expect(os.RemoveAll(layerDir)).To(Succeed())
-		Expect(os.RemoveAll(cnbDir)).To(Succeed())
 		Expect(os.RemoveAll(workingDir)).To(Succeed())
 	})
 
 	it("writes an httpd.conf file into the layer dir", func() {
-		path, err := config.Write(layerDir, workingDir, cnbDir)
+		path, err := config.Write(layerDir, workingDir)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(path).To(Equal(filepath.Join(layerDir, "httpd.conf")))
@@ -67,10 +51,10 @@ IncludeOptional {{ .UserInclude }}
 		contents, err := os.ReadFile(filepath.Join(layerDir, "httpd.conf"))
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(string(contents)).To(ContainSubstring("ServerAdmin admin@localhost"))
-		Expect(string(contents)).To(ContainSubstring(fmt.Sprintf("DocumentRoot %s/htdocs", workingDir)))
-		Expect(string(contents)).To(ContainSubstring("FPMSocket 127.0.0.1:9000"))
-		Expect(string(contents)).To(ContainSubstring("DisableHTTPSRedirect false"))
+		Expect(string(contents)).To(ContainSubstring("ServerAdmin \"admin@localhost\""))
+		Expect(string(contents)).To(ContainSubstring(fmt.Sprintf("DocumentRoot \"%s/htdocs\"", workingDir)))
+		Expect(string(contents)).To(ContainSubstring("SetHandler proxy:fcgi://127.0.0.1:9000"))
+		Expect(string(contents)).To(ContainSubstring("RewriteCond %{HTTPS} !=on"))
 		Expect(string(contents)).NotTo(ContainSubstring(fmt.Sprintf("IncludeOptional %s/.httpd.conf.d/*.conf", workingDir)))
 	})
 
@@ -79,11 +63,13 @@ IncludeOptional {{ .UserInclude }}
 			Expect(os.MkdirAll(filepath.Join(workingDir, ".httpd.conf.d"), os.ModePerm)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(workingDir, ".httpd.conf.d", "user.conf"), nil, os.ModePerm)).To(Succeed())
 		})
+
 		it.After(func() {
 			Expect(os.RemoveAll(filepath.Join(workingDir, ".httpd.conf.d"))).To(Succeed())
 		})
+
 		it("writes an httpd.conf with the user included conf into layerDir", func() {
-			path, err := config.Write(layerDir, workingDir, cnbDir)
+			path, err := config.Write(layerDir, workingDir)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(path).To(Equal(filepath.Join(layerDir, "httpd.conf")))
 			Expect(filepath.Join(layerDir, "httpd.conf")).To(BeARegularFile())
@@ -100,46 +86,38 @@ IncludeOptional {{ .UserInclude }}
 			Expect(os.Setenv("BP_PHP_ENABLE_HTTPS_REDIRECT", "false")).To(Succeed())
 			Expect(os.Setenv("BP_PHP_WEB_DIR", "some-web-dir")).To(Succeed())
 		})
+
 		it.After(func() {
 			Expect(os.Unsetenv("BP_PHP_SERVER_ADMIN")).To(Succeed())
 			Expect(os.Unsetenv("BP_PHP_ENABLE_HTTPS_REDIRECT")).To(Succeed())
 			Expect(os.Unsetenv("BP_PHP_WEB_DIR")).To(Succeed())
 		})
+
 		it("writes an httpd.conf that includes the env var values", func() {
-			path, err := config.Write(layerDir, workingDir, cnbDir)
+			path, err := config.Write(layerDir, workingDir)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(path).To(Equal(filepath.Join(layerDir, "httpd.conf")))
 
 			contents, err := os.ReadFile(filepath.Join(layerDir, "httpd.conf"))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(contents)).To(ContainSubstring("ServerAdmin some-server-admin"))
-			Expect(string(contents)).To(ContainSubstring(fmt.Sprintf("DocumentRoot %s/some-web-dir", workingDir)))
-			Expect(string(contents)).To(ContainSubstring("DisableHTTPSRedirect true"))
+			Expect(string(contents)).To(ContainSubstring("ServerAdmin \"some-server-admin\""))
+			Expect(string(contents)).To(ContainSubstring(fmt.Sprintf("DocumentRoot \"%s/some-web-dir\"", workingDir)))
+			Expect(string(contents)).NotTo(ContainSubstring("RewriteCond %{HTTPS} !=on"))
 		})
 	})
 
 	context("failure cases", func() {
-		context("when template is not parseable", func() {
-			it.Before(func() {
-				Expect(os.WriteFile(filepath.Join(cnbDir, "config", "httpd.conf"), []byte(`
-{{ .UserInclude
-		`), os.ModePerm)).To(Succeed())
-			})
-			it("returns an error", func() {
-				_, err := config.Write(layerDir, workingDir, cnbDir)
-				Expect(err).To(MatchError(ContainSubstring("unclosed action")))
-			})
-		})
-
 		context("when the BP_PHP_ENABLE_HTTPS_REDIRECT value cannot be parsed into a bool", func() {
 			it.Before(func() {
 				Expect(os.Setenv("BP_PHP_ENABLE_HTTPS_REDIRECT", "blah")).To(Succeed())
 			})
+
 			it.After(func() {
 				Expect(os.Unsetenv("BP_PHP_ENABLE_HTTPS_REDIRECT")).To(Succeed())
 			})
+
 			it("returns an error", func() {
-				_, err := config.Write(layerDir, workingDir, cnbDir)
+				_, err := config.Write(layerDir, workingDir)
 				Expect(err).To(MatchError(ContainSubstring("failed to pase $BP_PHP_ENABLE_HTTPS_REDIRECT into boolean:")))
 			})
 		})
@@ -148,8 +126,9 @@ IncludeOptional {{ .UserInclude }}
 			it.Before(func() {
 				Expect(os.WriteFile(filepath.Join(layerDir, "httpd.conf"), nil, 0400)).To(Succeed())
 			})
+
 			it("returns an error", func() {
-				_, err := config.Write(layerDir, workingDir, cnbDir)
+				_, err := config.Write(layerDir, workingDir)
 				Expect(err).To(MatchError(ContainSubstring("permission denied")))
 			})
 		})

--- a/fakes/config_writer.go
+++ b/fakes/config_writer.go
@@ -9,25 +9,23 @@ type ConfigWriter struct {
 		Receives  struct {
 			LayerPath  string
 			WorkingDir string
-			CnbPath    string
 		}
 		Returns struct {
 			String string
 			Error  error
 		}
-		Stub func(string, string, string) (string, error)
+		Stub func(string, string) (string, error)
 	}
 }
 
-func (f *ConfigWriter) Write(param1 string, param2 string, param3 string) (string, error) {
+func (f *ConfigWriter) Write(param1 string, param2 string) (string, error) {
 	f.WriteCall.mutex.Lock()
 	defer f.WriteCall.mutex.Unlock()
 	f.WriteCall.CallCount++
 	f.WriteCall.Receives.LayerPath = param1
 	f.WriteCall.Receives.WorkingDir = param2
-	f.WriteCall.Receives.CnbPath = param3
 	if f.WriteCall.Stub != nil {
-		return f.WriteCall.Stub(param1, param2, param3)
+		return f.WriteCall.Stub(param1, param2)
 	}
 	return f.WriteCall.Returns.String, f.WriteCall.Returns.Error
 }

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -104,7 +104,10 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(container).Should(Serve(ContainSubstring("SUCCESS: date loads.")).OnPort(8080).WithEndpoint("/index.php?date"))
+			Eventually(container).Should(Serve(ContainSubstring("SUCCESS: date loads.")).OnPort(8080).WithEndpoint("/index.php?date"), func() string {
+				logs, _ := docker.Container.Logs.Execute(container.ID)
+				return logs.String()
+			})
 		})
 	})
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
These changes ensure that this buildpack can run against a stack where the UIDs differ between build and run images.

The primary change here is to ensure we write the PID file to a group-writable location, `/tmp` in our case.

Additionally, I've switched out the packaging on the default conf file using tool for an implementation that uses embed.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This will enable this buildpack to run successfully on Jammy stacks.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
